### PR TITLE
feat: dependent tests and data sharing between tests

### DIFF
--- a/.github/workflows/nova-act-qa.yml
+++ b/.github/workflows/nova-act-qa.yml
@@ -28,15 +28,15 @@ jobs:
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: 'pip'
+          python-version: "3.11"
+          cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-      
+
       - name: Get installed Playwright version for caching
         run: echo "PLAYWRIGHT_VERSION=$(python -m playwright --version | cut -d ' ' -f 2)" >> $GITHUB_ENV
 
@@ -73,7 +73,7 @@ jobs:
           REPORT_RELATIVE_PATH=reports/report-${{ env.UNIQUE_ID }}.html
           echo "REPORT_ABSOLUTE_PATH=$GITHUB_WORKSPACE/$REPORT_RELATIVE_PATH" >> $GITHUB_ENV
           CPUS=$(python -c "import multiprocessing as mp; print(mp.cpu_count())")
-          python -m pytest --html=$REPORT_RELATIVE_PATH -n $CPUS
+          python -m pytest --html=$REPORT_RELATIVE_PATH -n $CPUS --dist loadgroup
 
       - name: Upload report
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -161,7 +161,47 @@ See the [pytest-html](https://pytest-html.readthedocs.io/en/latest/) documentati
 
 ## Test Configuration
 
-The `pyproject.toml` file has a `[tool.pytest.ini_options]` section which defines the pytest configuration for the tests. This can be extended to customize your tests as needed.
+The `pyproject.toml` file has a `[tool.pytest.ini_options]` section which defines the pytest configuration for the tests. The default settings include:
+
+- `-n auto`: Automatically detects CPU cores and runs tests in parallel
+- `--dist loadgroup`: Distributes tests in the same group on the same worker to enable sequential runs
+- `--html=reports/report.html`: Defines the location to write the pytest HTML report
+- `--self-contained-html`: Creates a standalone HTML report file with embedded assets
+- `--add-nova-act-report`: Integrates Nova Act screenshots and logs into the HTML report
+
+This configuration can be extended to customize your tests as needed.
+
+### Test Grouping for Sequential Execution
+
+When using `pytest-xdist` for parallel execution, tests that need to share data or run sequentially can be grouped using the `@pytest.mark.xdist_group` decorator. This feature requires the `--dist loadgroup` option (configured by default) to ensure tests in the same group run on the same worker process in order.
+
+For example:
+
+```python
+@pytest.mark.xdist_group("test_group")
+def test_one():
+    pass
+
+@pytest.mark.xdist_group("test_group")
+def test_two():
+    pass
+```
+
+This ensures that dependent tests run sequentially while maintaining parallel execution for independent tests. See [test_share_data.py](src/nova_act_qa/tests/test_share_data.py) for an example of this. [See the pytest-xdist docs for more information](https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus).
+
+### Sharing Data Between Tests
+
+Pytest provides a built-in cache that allows tests to share data within the same test run. This is useful for storing data that one test extracts and another test consumes.
+
+```python
+def test_store_data(pytestconfig):
+    pytestconfig.cache.set("key", "value")
+
+def test_retrieve_data(pytestconfig):
+    data = pytestconfig.cache.get("key", "default")
+```
+
+> Note: When tests need to share data within the same test run, you must use the `@pytest.mark.xdist_group` decorator from the previous section to ensure they run on the same worker process. See [test_share_data.py](src/nova_act_qa/tests/test_share_data.py) for a complete example of data sharing between dependent tests using both the cache and xdist grouping.
 
 ## Test Automation
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,17 @@
+# Copyright Amazon Inc
+
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Global pytest configuration to handle Nova Act compatibility issues."""
 
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "python-dotenv (>=1.1.0,<2.0.0)",
   "json-compare-deep (>=2.0,<3.0)",
   "pytest-xdist (>=3.6.1,<4.0.0)",
-  "pytest-html-nova-act (>=1.0.0,<2.0.0)",
+  "pytest-html-nova-act (>=1.0.0,<2.0.0)"
 ]
 requires-python = ">=3.11"
 
@@ -33,7 +33,7 @@ dependencies = [
 filterwarnings = [
     "ignore::pytest.PytestUnhandledThreadExceptionWarning",
 ]
-addopts = "-n auto --html=reports/report.html --self-contained-html --add-nova-act-report"
+addopts = "-n auto --dist loadgroup --html=reports/report.html --self-contained-html --add-nova-act-report"
 
 
 [tool.hatch.build]

--- a/src/nova_act_qa/tests/test_share_data.py
+++ b/src/nova_act_qa/tests/test_share_data.py
@@ -1,0 +1,82 @@
+# Copyright Amazon Inc
+
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The tests in this file demonstrate how to share data between tests using pytest's built-in cache
+and @pytest.mark.xdist_group to ensure tests run sequentially on the same worker process.
+"""
+
+from pydantic import BaseModel
+import pytest
+from nova_act_qa.utils.nova_act import NovaAct
+
+# Expected Blog Post name to assert
+expected_blog_post_title = "Useful, reliable agents from prototype to production"
+expected_blog_post_author = "Amazon AGI"
+expected_blog_post_date = "July 16, 2025"
+
+
+# Schema of the data to extract
+class BlogDetailsSchema(BaseModel):
+    title: str
+    author: str
+    date: str
+
+
+# Name of the cache key to store the data in
+blog_post_cache_key = "blog_post_details"
+
+# Name of xdist group to run tests sequentially on same worker
+xdist_group_name = "share_data"
+
+
+@pytest.mark.xdist_group(xdist_group_name)
+@pytest.mark.parametrize(
+    "nova", ["https://labs.amazon.science/blog/prototype-to-production"], indirect=True
+)
+def test_extract_data(nova: NovaAct, pytestconfig: pytest.Config):
+    """First test that extracts and stores shared data."""
+
+    # Extract the data
+    result = nova.act(
+        "Get the Blog Post title", schema=BlogDetailsSchema.model_json_schema()
+    )
+    data = nova.is_result_valid(result)
+    blog_post_details = BlogDetailsSchema.model_validate(data)
+
+    # Assert the data
+    assert expected_blog_post_title == blog_post_details.title
+    assert expected_blog_post_author == blog_post_details.author
+    assert expected_blog_post_date == blog_post_details.date
+
+    # Store the data for the second test to use
+    pytestconfig.cache.set(blog_post_cache_key, blog_post_details.model_dump_json())
+
+
+@pytest.mark.xdist_group(xdist_group_name="share_data")
+@pytest.mark.parametrize("nova", ["https://labs.amazon.science"], indirect=True)
+def test_consume_data(nova: NovaAct, pytestconfig: pytest.Config):
+    """Second test that uses the shared data from the first test."""
+
+    nova.act("Go to the Blog page")
+
+    # Get the data from the previous test
+    cached_blog_post_details = pytestconfig.cache.get(blog_post_cache_key, "{}")
+    blog_post_details = BlogDetailsSchema.model_validate_json(cached_blog_post_details)
+
+    # Use the data
+    nova.act(
+        f"Select the Blog Post {blog_post_details.title} by {blog_post_details.author} on {blog_post_details.date}"
+    )
+    nova.test_bool(f"Blog Post {blog_post_details.title} is displayed")


### PR DESCRIPTION
*Description of changes:*

- Add `test_share_data` test to demonstrate how to share data between tests using pytest's built-in cache and `@pytest.mark.xdist_group` marker to ensure dependent tests run sequentially on the same pytest-xdist worker process
- Update pytest config with `--dist loadgroup` to ensure pytest-xdist distributes tests by groups
- Update documentation with details on the configuration for this
- Update GitHub Workflow to explicitly set `--dist loadgroup` as it wasn't being picked up from `pyproject.toml` (?)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
